### PR TITLE
docs: link to the hosted playgrounds from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ MIT
 
 ---
 
-**[WaveSpeed AI](https://wavespeed.ai/)** — hosted inference for image, video, audio and 3D models.
+**[WaveSpeed AI](https://wavespeed.ai/)** — AI image & video generation platform.
 Try it in the browser: **[Image generator](https://wavespeed.ai/image-generator)** · **[Video generator](https://wavespeed.ai/video-generator)**

--- a/README.md
+++ b/README.md
@@ -170,3 +170,8 @@ npm test -- tests/test_api.ts -t "run success"
 ## License
 
 MIT
+
+---
+
+**[WaveSpeed AI](https://wavespeed.ai/)** — hosted inference for image, video, audio and 3D models.
+Try it in the browser: **[Image generator](https://wavespeed.ai/image-generator)** · **[Video generator](https://wavespeed.ai/video-generator)**


### PR DESCRIPTION
Adds a consistent footer to the README pointing at the product and the two browser playgrounds. Every repo under the org carried a link to `wavespeed.ai` at most; none linked to the image or video generator, so a reader who wanted to *try* a model rather than integrate one had no route from here.

```markdown
---

**[WaveSpeed AI](https://wavespeed.ai/)** — hosted inference for image, video, audio and 3D models.
Try it in the browser: **[Image generator](https://wavespeed.ai/image-generator)** · **[Video generator](https://wavespeed.ai/video-generator)**
```

README only — no code, no build, no dependency changes. All three URLs return HTTP 200.